### PR TITLE
Enable import of *.freeaps files

### DIFF
--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -98,5 +98,27 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>FreeAPS settings</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>freeaps.settings</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>freeaps</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Loop/Info.plist
+++ b/Loop/Info.plist
@@ -98,6 +98,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Last update (172) broke the import of settings in FreeAPS. This PR replaces the code that was accidentally (?) deleted in 172 and allows for import of settings files (*.freeaps) 