### PR TITLE
Update base strings to to match localized strings

### DIFF
--- a/Loop/Base.lproj/Localizable.strings
+++ b/Loop/Base.lproj/Localizable.strings
@@ -409,7 +409,7 @@
 
 "Max basal limit" = "Max basal limit";
 
-"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting.\nThis setting is ignored if microboluses are disabled." = "Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting.\nThis setting is ignored if microboluses are disabled.";
+"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled." = "Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled.";
 
 "Temporary overrides" = "Temporary overrides";
 

--- a/Loop/Views/Microboluses/MicrobolusView.swift
+++ b/Loop/Views/Microboluses/MicrobolusView.swift
@@ -108,7 +108,7 @@ struct MicrobolusView: View {
 
     private var basalRateSection: some View {
         Section(footer:
-            Text("Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled.")
+            Text("Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled.")
         ) {
             Picker(selection: $viewModel.basalRateMultiplierIndex, label: Text("Basal Rate Multiplier")) {
                 ForEach(0 ..< viewModel.basalRateMultiplierValues.count) { index in

--- a/Loop/da.lproj/Localizable.strings
+++ b/Loop/da.lproj/Localizable.strings
@@ -411,7 +411,7 @@
 
 "Max basal limit" = "Max basal grænse";
 
-"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting.\nThis setting is ignored if microboluses are disabled." = "Begrænser den maksimale basalrate til et multiplum af den planlagte basalrate. Værdien kan ikke overstige din maksimale basalrate indstilling.\nDenne indstilling ignoreres, hvis mikrobolus er deaktiveret.";
+"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled." = "Begrænser den maksimale basalrate til et multiplum af den planlagte basalrate. Værdien kan ikke overstige din maksimale basalrate indstilling. Denne indstilling ignoreres, hvis mikrobolus er deaktiveret.";
 
 "Temporary overrides" = "Midlertidige overrides";
 

--- a/Loop/de.lproj/Localizable.strings
+++ b/Loop/de.lproj/Localizable.strings
@@ -411,7 +411,7 @@
 
 "Max basal limit" = "Maximales Basallimit";
 
-"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting.\nThis setting is ignored if microboluses are disabled." = "Begrenzt die Basalrate auf ein Vielfaches der geplanten Basalrate in Loop. Der Wert kann dabei die maximale Basalrate nicht überschreiten.\nDiese Einstellung wird bei deaktiviertem Mikrobolus ignoriert.";
+"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled." = "Begrenzt die Basalrate auf ein Vielfaches der geplanten Basalrate in Loop. Der Wert kann dabei die maximale Basalrate nicht überschreiten.\nDiese Einstellung wird bei deaktiviertem Mikrobolus ignoriert.";
 
 "Temporary overrides" = "Vorübergehende Anpassungen";
 

--- a/Loop/nb.lproj/Localizable.strings
+++ b/Loop/nb.lproj/Localizable.strings
@@ -411,7 +411,7 @@
 
 "Max basal limit" = "Maks basalgrense";
 
-"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting.\nThis setting is ignored if microboluses are disabled." = "Begrenser maksimal midlertidig basalrate til et multiplum av programmert basalrate. Verdien kan ikke overstige innstillingen for maksimal basalgrense\nDenne innstillingen ignoreres hvis mikroboluser er deaktivert.";
+"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled." = "Begrenser maksimal midlertidig basalrate til et multiplum av programmert basalrate. Verdien kan ikke overstige innstillingen for maksimal basalgrense\nDenne innstillingen ignoreres hvis mikroboluser er deaktivert.";
 
 "Temporary overrides" = "Midlertidig overstyring";
 

--- a/Loop/nl.lproj/Localizable.strings
+++ b/Loop/nl.lproj/Localizable.strings
@@ -411,7 +411,7 @@
 
 "Max basal limit" = "Max basaal limiet";
 
-"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting.\nThis setting is ignored if microboluses are disabled." = "Beperkt de maximale basaal tot een veelvoud van de ingestelde basaal. De waarde kan niet hoger zijn dan de maximale basaal.\nDeze instelling wordt genegeerd als microbolussen zijn uitgeschakeld.";
+"Limits the maximum basal rate to a multiple of the scheduled basal rate in loop. The value cannot exceed your maximum basal rate setting. This setting is ignored if microboluses are disabled." = "Beperkt de maximale basaal tot een veelvoud van de ingestelde basaal. De waarde kan niet hoger zijn dan de maximale basaal.\nDeze instelling wordt genegeerd als microbolussen zijn uitgeschakeld.";
 
 "Temporary overrides" = "Tijdelijke overrides";
 


### PR DESCRIPTION
Sorry to bother you with this. I know you said this workspace is frozen, but it seems it's still kicking 🤣. The source file (base) has two "\n" that the localized strings haven't. If you will accept this PR and the next in the workspace I guess I also need to make (the Loop commit ref) 🙏 the Dutch, German, Danish, Norwegian and Swedish localizations will show all strings translated (right now one string isn't because of this). Thanks. 